### PR TITLE
Use Google email to identify current user

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,4 +37,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'com.google.firebase:firebase-analytics:17.2.2'
     implementation 'com.google.firebase:firebase-firestore:21.4.1'
+    implementation 'commons-codec:commons-codec:1.13'
 }

--- a/app/src/main/java/com/sherblabs/wisht/activities/MainActivity.kt
+++ b/app/src/main/java/com/sherblabs/wisht/activities/MainActivity.kt
@@ -1,10 +1,18 @@
 package com.sherblabs.wisht.activities
 
+import android.accounts.AccountManager
+import android.content.Context
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import com.sherblabs.wisht.R
+import org.apache.commons.codec.binary.Hex
+import org.apache.commons.codec.digest.DigestUtils
+
+const val CURRENT_USERNAME_KEY = "current_user"
+const val DEFAULT_USERNAME = "default_user"
 
 class MainActivity : AppCompatActivity() {
 
@@ -12,11 +20,67 @@ class MainActivity : AppCompatActivity() {
         // test comment.
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        setupUser()
     }
 
     fun viewMyList(view: View) {
         // second test comment.
         val intent = Intent(this, MyListActivity::class.java)
+        intent.putExtra(CURRENT_USERNAME_KEY, getCurrentUsername())
         startActivity(intent)
+    }
+
+    private fun setupUser() {
+        if (!currentUserIsSet()) {
+            askForUserAccount()
+        }
+    }
+
+    private fun askForUserAccount() {
+        val intent = AccountManager.newChooseAccountIntent(
+            null,
+            null,
+            arrayOf("com.google"),
+            false,
+            null,
+            null,
+            null,
+            null)
+        startActivityForResult(intent, 10)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == 10) {
+            val accountName = data?.extras?.get(AccountManager.KEY_ACCOUNT_NAME)
+            if (accountName != null) {
+                setCurrentUsername(accountName.toString())
+            } else {
+                setCurrentUsername(DEFAULT_USERNAME)
+            }
+        }
+    }
+
+    private fun currentUserIsSet(): Boolean {
+        return getCurrentUsername() != null
+    }
+
+    private fun getCurrentUsername(): String? {
+        return getSharedPreferences().getString(CURRENT_USERNAME_KEY, null)
+    }
+
+    private fun setCurrentUsername(username: String) {
+        getSharedPreferences().edit().putString(CURRENT_USERNAME_KEY,
+            getFirebaseKeyForUsername(username)).apply()
+    }
+
+    private fun getSharedPreferences(): SharedPreferences {
+        return getSharedPreferences(
+            "com.sherblabs.wisht", Context.MODE_PRIVATE
+        )
+    }
+
+    private fun getFirebaseKeyForUsername(username: String): String {
+        return String(Hex.encodeHex(DigestUtils.sha1(username)))
     }
 }

--- a/app/src/main/java/com/sherblabs/wisht/activities/MyListActivity.kt
+++ b/app/src/main/java/com/sherblabs/wisht/activities/MyListActivity.kt
@@ -3,24 +3,24 @@ package com.sherblabs.wisht.activities
 import android.app.AlertDialog
 import android.os.Bundle
 import android.text.InputType
-import android.util.Log
 import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.EditText
 import android.widget.ListView
 import androidx.appcompat.app.AppCompatActivity
-import com.google.firebase.database.*
 import com.sherblabs.wisht.R
-
-const val LIST_KEY = "test_firebase_list"
+import com.sherblabs.wisht.controllers.WishListController
 
 class MyListActivity : AppCompatActivity() {
+
+    private lateinit var wishList: WishListController
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_my_list)
 
-        initializeListViewRefresher()
+        val username = intent.getStringExtra(CURRENT_USERNAME_KEY) ?: DEFAULT_USERNAME
+        wishList = WishListController(username, ::refreshListView)
     }
 
     fun onClickAddItem(view: View) {
@@ -42,28 +42,7 @@ class MyListActivity : AppCompatActivity() {
     }
 
     private fun addItemToList(value: String) {
-        val database = FirebaseDatabase.getInstance()
-        val myRef = database.getReference(LIST_KEY).push()
-        myRef.setValue(value)
-    }
-
-    private fun initializeListViewRefresher(){
-        val database = FirebaseDatabase.getInstance()
-        val myRef = database.getReference(LIST_KEY)
-        myRef.addValueEventListener(object : ValueEventListener {
-            override fun onDataChange(dataSnapshot: DataSnapshot) {
-                val map = dataSnapshot.getValue(object : GenericTypeIndicator<Map<String, String>>() {})
-                if (map != null) {
-                    refreshListView(map.values.toList())
-                } else {
-                    Log.w(MyListActivity::class.java.toString(), "Map is null.")
-                }
-            }
-            override fun onCancelled(error: DatabaseError) {
-                // Failed to read value
-                Log.w(MyListActivity::class.java.toString(), "Failed to read value.", error.toException())
-            }
-        })
+        wishList.add(value)
     }
 
     private fun refreshListView(list: List<String>) {

--- a/app/src/main/java/com/sherblabs/wisht/controllers/WishListController.kt
+++ b/app/src/main/java/com/sherblabs/wisht/controllers/WishListController.kt
@@ -1,0 +1,38 @@
+package com.sherblabs.wisht.controllers
+
+import android.util.Log
+import com.google.firebase.database.*
+import com.sherblabs.wisht.activities.MyListActivity
+
+class WishListController(
+    username: String,
+    private val onDataChangeCallback: (List<String>) -> Unit) {
+
+    private var dbList = FirebaseDatabase.getInstance().reference.child(username)
+
+    init {
+        onDataChange()
+    }
+
+    fun add(value: String) {
+        val myRef = dbList.push()
+        myRef.setValue(value)
+    }
+
+    private fun onDataChange() {
+        dbList.addValueEventListener(object : ValueEventListener {
+            override fun onDataChange(dataSnapshot: DataSnapshot) {
+                val map = dataSnapshot.getValue(object : GenericTypeIndicator<Map<String, String>>() {})
+                if (map != null) {
+                    onDataChangeCallback(map.values.toList())
+                } else {
+                    Log.w(MyListActivity::class.java.toString(), "Map is null.")
+                }
+            }
+            override fun onCancelled(error: DatabaseError) {
+                // Failed to read value
+                Log.w(MyListActivity::class.java.toString(), "Failed to read value.", error.toException())
+            }
+        })
+    }
+}


### PR DESCRIPTION
Design:
- ask for the user's Google email on Main Activity
- store encrypted email address on user's device in Shared Preferences
- use encrypted email address as the key to the user's Firebase wish
list
- break out Wish List interaction with database into WishListController

Testing: launched app, selected one of my Google accounts, verified
unique list (not default list) is retrieved and updated in Firebase for
my account