### PR TITLE
Fix My List margins

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar" >
         <activity android:name="com.sherblabs.wisht.activities.MyListActivity" >
         </activity>
         <activity android:name="com.sherblabs.wisht.activities.MainActivity" >

--- a/app/src/main/java/com/sherblabs/wisht/activities/MainActivity.kt
+++ b/app/src/main/java/com/sherblabs/wisht/activities/MainActivity.kt
@@ -1,12 +1,12 @@
 package com.sherblabs.wisht.activities
 
 import android.accounts.AccountManager
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import com.sherblabs.wisht.R
 import org.apache.commons.codec.binary.Hex
 import org.apache.commons.codec.digest.DigestUtils
@@ -14,7 +14,7 @@ import org.apache.commons.codec.digest.DigestUtils
 const val CURRENT_USERNAME_KEY = "current_user"
 const val DEFAULT_USERNAME = "default_user"
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // test comment.

--- a/app/src/main/java/com/sherblabs/wisht/activities/MyListActivity.kt
+++ b/app/src/main/java/com/sherblabs/wisht/activities/MyListActivity.kt
@@ -18,6 +18,7 @@ class MyListActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_my_list)
+        setSupportActionBar(findViewById(R.id.my_toolbar))
 
         val username = intent.getStringExtra(CURRENT_USERNAME_KEY) ?: DEFAULT_USERNAME
         wishList = WishListController(username, ::refreshListView)

--- a/app/src/main/res/layout/activity_my_list.xml
+++ b/app/src/main/res/layout/activity_my_list.xml
@@ -7,17 +7,28 @@
     android:layout_height="match_parent"
     tools:context=".activities.MyListActivity">
 
-    <ListView
-        android:id="@+id/listView"
-        android:layout_width="393dp"
-        android:layout_height="665dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="64dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-    </ListView>
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/my_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        tools:ignore="MissingConstraints" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/my_toolbar">
+
+        <ListView
+            android:id="@+id/listView"
+            android:layout_width="429dp"
+            android:layout_height="wrap_content"
+            tools:ignore="MissingConstraints"
+            tools:layout_editor_absoluteY="394dp" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/floatingActionButton"

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -5,8 +5,6 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:textStyle="bold"
-    android:layout_marginLeft="10dp"
-    android:layout_marginTop="5dp"
-    android:padding="4dp"
+    android:padding="20dp"
     android:textColor="#000000"
     />


### PR DESCRIPTION
Design:
- default activities to not display an ActionBar by setting the theme to
NoActionBar. That way we can add our own Toolbar to each activity
individually
- don't display any Toolbar on MainActivity
- explicitly add the Toolbar so that we can constrain other elements in
the layout to it (i.e., make it so that the Toolbar doesn't cover up
things beneath it).
- add nested ContraintLayout to constrain the list view to the bottom of
the Toolbar
- add padding to list items instead of margin since margin creates space
between elements, while padding makes the actual element bigger. The
reason we don't want space in between elements is that that space is not
clickable. By using padding, the whole element (list item) fills up the
space (gets bigger), which means the user can tap anywhere on the item
to result in an "onClick" for that item.

Testing: tested on Moto g5 plus and Pixel 2 with 12 items in the list.
List becomes scrollable when there are too many to fit in the screen.